### PR TITLE
Add prefer-loose-nullish-equality rule

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,15 @@
 module.exports = {
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.[tj]sx?$': 'ts-jest',
+  },
+  transformIgnorePatterns: [
+    '/node_modules/(?!(ts-api-utils)/)',
+  ],
+  globals: {
+    'ts-jest': {
+      tsconfig: {
+        allowJs: true,
+      },
+    },
   },
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,9 +2,7 @@ module.exports = {
   transform: {
     '^.+\\.[tj]sx?$': 'ts-jest',
   },
-  transformIgnorePatterns: [
-    '/node_modules/(?!(ts-api-utils)/)',
-  ],
+  transformIgnorePatterns: ['/node_modules/(?!(ts-api-utils)/)'],
   globals: {
     'ts-jest': {
       tsconfig: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,17 +3,20 @@ import { TSESLint } from '@typescript-eslint/experimental-utils';
 import { castToBoolean } from './rules/cast-to-boolean';
 import { noColorLiterals } from './rules/no-color-literals';
 import { noGlobalStyles } from './rules/no-global-styles';
+import { preferLooseNullishEquality } from './rules/prefer-loose-nullish-equality';
 
 const rules = {
   'cast-to-boolean': castToBoolean,
   'no-color-literals': noColorLiterals,
   'no-global-styles': noGlobalStyles,
+  'prefer-loose-nullish-equality': preferLooseNullishEquality,
 };
 
 const recommendedRules: Record<string, TSESLint.Linter.RuleEntry> = {
   '@mll-lab/cast-to-boolean': 'error',
   '@mll-lab/no-color-literals': 'error',
   '@mll-lab/no-global-styles': 'error',
+  '@mll-lab/prefer-loose-nullish-equality': 'error',
 };
 
 type Plugin = {

--- a/src/rules/prefer-loose-nullish-equality.ts
+++ b/src/rules/prefer-loose-nullish-equality.ts
@@ -1,0 +1,292 @@
+/**
+ * Enforces loose equality (==, !=) for nullish comparisons per MLL coding guidelines.
+ * https://gitlab.mll/documentation/coding-guidelines/-/wikis/java-type-script#comparisons-with-potentially-nullish-values
+ *
+ * When checking if a value is nullish (null or undefined), prefer loose equality because:
+ * - In JavaScript: null !== undefined but null == undefined
+ * - Loose comparison to null covers both cases with a single check
+ *
+ * Examples:
+ *
+ * // Bad
+ * if (value === null || value === undefined) { }
+ * if (value === null) { }  // when value could also be undefined
+ * if (value !== null && value !== undefined) { }
+ *
+ * // Good
+ * if (value == null) { }
+ * if (value != null) { }
+ *
+ * // Still OK (not nullish comparisons)
+ * if (typeof value === 'undefined') { }  // typeof check
+ * if (x === y) { }  // comparing two variables
+ */
+
+import {
+  ESLintUtils,
+  TSESLint,
+  TSESTree,
+} from '@typescript-eslint/experimental-utils';
+
+type MessageIds = 'preferLooseNullishEquality';
+
+export const preferLooseNullishEquality: TSESLint.RuleModule<
+  MessageIds,
+  Array<never>
+> = ESLintUtils.RuleCreator((name) => name)({
+  name: 'prefer-loose-nullish-equality',
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Prefer loose equality (== null) over strict equality for nullish checks',
+      recommended: 'error',
+    },
+    messages: {
+      preferLooseNullishEquality:
+        'Use loose equality ({{ operator }} null) for nullish checks. In JavaScript, null {{ operator }} undefined is true.',
+    },
+    schema: [],
+    fixable: 'code',
+  },
+  defaultOptions: [],
+  create(context) {
+    const sourceCode = context.getSourceCode();
+
+    /**
+     * Check if a node is the literal null
+     */
+    function isNullLiteral(node: TSESTree.Node): boolean {
+      return node.type === 'Literal' && node.value === null;
+    }
+
+    /**
+     * Check if a node is the identifier undefined
+     */
+    function isUndefinedIdentifier(node: TSESTree.Node): boolean {
+      return node.type === 'Identifier' && node.name === 'undefined';
+    }
+
+    /**
+     * Check if a node is a nullish value (null or undefined)
+     */
+    function isNullish(node: TSESTree.Node): boolean {
+      return isNullLiteral(node) || isUndefinedIdentifier(node);
+    }
+
+    /**
+     * Check if a node is a typeof expression
+     */
+    function isTypeofExpression(node: TSESTree.Node): boolean {
+      return node.type === 'UnaryExpression' && node.operator === 'typeof';
+    }
+
+    /**
+     * Get the non-nullish side of a binary expression
+     */
+    function getComparedExpression(
+      node: TSESTree.BinaryExpression,
+    ): TSESTree.Node | null {
+      if (isNullish(node.left)) {
+        return node.right;
+      }
+      if (isNullish(node.right)) {
+        return node.left;
+      }
+      return null;
+    }
+
+    /**
+     * Check if a BinaryExpression checks for null
+     */
+    function checksNull(node: TSESTree.BinaryExpression): boolean {
+      return isNullLiteral(node.left) || isNullLiteral(node.right);
+    }
+
+    /**
+     * Check if a BinaryExpression checks for undefined
+     */
+    function checksUndefined(node: TSESTree.BinaryExpression): boolean {
+      return isUndefinedIdentifier(node.left) || isUndefinedIdentifier(node.right);
+    }
+
+    /**
+     * Compare two AST nodes for semantic equivalence
+     */
+    function areExpressionsEquivalent(
+      node1: TSESTree.Node | null,
+      node2: TSESTree.Node | null,
+    ): boolean {
+      if (!node1 || !node2) {
+        return false;
+      }
+
+      // Use source code comparison as a simple heuristic
+      return sourceCode.getText(node1) === sourceCode.getText(node2);
+    }
+
+    /**
+     * Report a strict nullish comparison and provide a fix
+     */
+    function reportStrictNullishComparison(
+      node: TSESTree.BinaryExpression,
+    ): void {
+      const newOperator = node.operator === '===' ? '==' : '!=';
+      const comparedExpr = getComparedExpression(node);
+
+      if (!comparedExpr) {
+        return;
+      }
+
+      context.report({
+        node,
+        messageId: 'preferLooseNullishEquality',
+        data: {
+          operator: newOperator,
+        },
+        fix(fixer) {
+          const valueText = sourceCode.getText(comparedExpr);
+          const fixed = `${valueText} ${newOperator} null`;
+          return fixer.replaceText(node, fixed);
+        },
+      });
+    }
+
+    /**
+     * Report a combined null/undefined check and provide a fix
+     */
+    function reportCombinedNullishCheck(
+      node: TSESTree.LogicalExpression,
+      operator: '===' | '!==',
+    ): void {
+      const newOperator = operator === '===' ? '==' : '!=';
+      const comparedExpr = getComparedExpression(
+        node.left as TSESTree.BinaryExpression,
+      );
+
+      if (!comparedExpr) {
+        return;
+      }
+
+      context.report({
+        node,
+        messageId: 'preferLooseNullishEquality',
+        data: {
+          operator: newOperator,
+        },
+        fix(fixer) {
+          const valueText = sourceCode.getText(comparedExpr);
+          const fixed = `${valueText} ${newOperator} null`;
+          return fixer.replaceText(node, fixed);
+        },
+      });
+    }
+
+    return {
+      BinaryExpression(node: TSESTree.BinaryExpression): void {
+        // Only check strict equality operators
+        if (node.operator !== '===' && node.operator !== '!==') {
+          return;
+        }
+
+        // Don't flag typeof checks
+        if (isTypeofExpression(node.left) || isTypeofExpression(node.right)) {
+          return;
+        }
+
+        // Check if this is part of a combined null/undefined check
+        // If so, the LogicalExpression visitor will handle it
+        const { parent } = node;
+        if (parent && parent.type === 'LogicalExpression') {
+          const sibling = parent.left === node ? parent.right : parent.left;
+
+          // Check if both sides are nullish checks on the same variable
+          if (
+            sibling &&
+            sibling.type === 'BinaryExpression' &&
+            sibling.operator === node.operator &&
+            (isNullish(node.left) || isNullish(node.right)) &&
+            (isNullish(sibling.left) || isNullish(sibling.right))
+          ) {
+            const thisExpr = getComparedExpression(node);
+            const siblingExpr = getComparedExpression(sibling);
+
+            if (
+              thisExpr &&
+              siblingExpr &&
+              areExpressionsEquivalent(thisExpr, siblingExpr)
+            ) {
+              // Skip this node - the LogicalExpression visitor will handle it
+              return;
+            }
+          }
+        }
+
+        // Check if comparing to null or undefined
+        if (isNullish(node.left) || isNullish(node.right)) {
+          reportStrictNullishComparison(node);
+        }
+      },
+
+      LogicalExpression(node: TSESTree.LogicalExpression): void {
+        const { left, right, operator } = node;
+
+        // Must be binary expressions on both sides
+        if (
+          left.type !== 'BinaryExpression' ||
+          right.type !== 'BinaryExpression'
+        ) {
+          return;
+        }
+
+        // Pattern 2: a === null || a === undefined
+        if (
+          operator === '||' &&
+          left.operator === '===' &&
+          right.operator === '==='
+        ) {
+          const leftChecksNull = checksNull(left);
+          const leftChecksUndefined = checksUndefined(left);
+          const rightChecksNull = checksNull(right);
+          const rightChecksUndefined = checksUndefined(right);
+
+          const hasNullCheck = leftChecksNull || rightChecksNull;
+          const hasUndefinedCheck = leftChecksUndefined || rightChecksUndefined;
+
+          if (hasNullCheck && hasUndefinedCheck) {
+            const leftExpr = getComparedExpression(left);
+            const rightExpr = getComparedExpression(right);
+
+            if (areExpressionsEquivalent(leftExpr, rightExpr)) {
+              reportCombinedNullishCheck(node, '===');
+            }
+          }
+        }
+
+        // Pattern 3: a !== null && a !== undefined
+        if (
+          operator === '&&' &&
+          left.operator === '!==' &&
+          right.operator === '!=='
+        ) {
+          const leftChecksNull = checksNull(left);
+          const leftChecksUndefined = checksUndefined(left);
+          const rightChecksNull = checksNull(right);
+          const rightChecksUndefined = checksUndefined(right);
+
+          const hasNullCheck = leftChecksNull || rightChecksNull;
+          const hasUndefinedCheck = leftChecksUndefined || rightChecksUndefined;
+
+          if (hasNullCheck && hasUndefinedCheck) {
+            const leftExpr = getComparedExpression(left);
+            const rightExpr = getComparedExpression(right);
+
+            if (areExpressionsEquivalent(leftExpr, rightExpr)) {
+              reportCombinedNullishCheck(node, '!==');
+            }
+          }
+        }
+      },
+    };
+  },
+});

--- a/src/rules/prefer-loose-nullish-equality.ts
+++ b/src/rules/prefer-loose-nullish-equality.ts
@@ -23,6 +23,7 @@
  */
 
 import {
+  AST_NODE_TYPES,
   ESLintUtils,
   TSESLint,
   TSESTree,
@@ -57,14 +58,16 @@ export const preferLooseNullishEquality: TSESLint.RuleModule<
      * Check if a node is the literal null
      */
     function isNullLiteral(node: TSESTree.Node): boolean {
-      return node.type === 'Literal' && node.value === null;
+      return node.type === AST_NODE_TYPES.Literal && node.value === null;
     }
 
     /**
      * Check if a node is the identifier undefined
      */
     function isUndefinedIdentifier(node: TSESTree.Node): boolean {
-      return node.type === 'Identifier' && node.name === 'undefined';
+      return (
+        node.type === AST_NODE_TYPES.Identifier && node.name === 'undefined'
+      );
     }
 
     /**
@@ -78,7 +81,10 @@ export const preferLooseNullishEquality: TSESLint.RuleModule<
      * Check if a node is a typeof expression
      */
     function isTypeofExpression(node: TSESTree.Node): boolean {
-      return node.type === 'UnaryExpression' && node.operator === 'typeof';
+      return (
+        node.type === AST_NODE_TYPES.UnaryExpression &&
+        node.operator === 'typeof'
+      );
     }
 
     /**
@@ -107,7 +113,9 @@ export const preferLooseNullishEquality: TSESLint.RuleModule<
      * Check if a BinaryExpression checks for undefined
      */
     function checksUndefined(node: TSESTree.BinaryExpression): boolean {
-      return isUndefinedIdentifier(node.left) || isUndefinedIdentifier(node.right);
+      return (
+        isUndefinedIdentifier(node.left) || isUndefinedIdentifier(node.right)
+      );
     }
 
     /**
@@ -197,13 +205,12 @@ export const preferLooseNullishEquality: TSESLint.RuleModule<
         // Check if this is part of a combined null/undefined check
         // If so, the LogicalExpression visitor will handle it
         const { parent } = node;
-        if (parent && parent.type === 'LogicalExpression') {
+        if (parent && parent.type === AST_NODE_TYPES.LogicalExpression) {
           const sibling = parent.left === node ? parent.right : parent.left;
 
           // Check if both sides are nullish checks on the same variable
           if (
-            sibling &&
-            sibling.type === 'BinaryExpression' &&
+            sibling.type === AST_NODE_TYPES.BinaryExpression &&
             sibling.operator === node.operator &&
             (isNullish(node.left) || isNullish(node.right)) &&
             (isNullish(sibling.left) || isNullish(sibling.right))
@@ -233,8 +240,8 @@ export const preferLooseNullishEquality: TSESLint.RuleModule<
 
         // Must be binary expressions on both sides
         if (
-          left.type !== 'BinaryExpression' ||
-          right.type !== 'BinaryExpression'
+          left.type !== AST_NODE_TYPES.BinaryExpression ||
+          right.type !== AST_NODE_TYPES.BinaryExpression
         ) {
           return;
         }

--- a/src/rules/prefer-loose-nullish-equality.ts
+++ b/src/rules/prefer-loose-nullish-equality.ts
@@ -1,6 +1,5 @@
 /**
  * Enforces loose equality (==, !=) for nullish comparisons per MLL coding guidelines.
- * https://gitlab.mll/documentation/coding-guidelines/-/wikis/java-type-script#comparisons-with-potentially-nullish-values
  *
  * When checking if a value is nullish (null or undefined), prefer loose equality because:
  * - In JavaScript: null !== undefined but null == undefined

--- a/src/rules/prefer-loose-nullish-equality.ts
+++ b/src/rules/prefer-loose-nullish-equality.ts
@@ -54,32 +54,20 @@ export const preferLooseNullishEquality: TSESLint.RuleModule<
   create(context) {
     const sourceCode = context.getSourceCode();
 
-    /**
-     * Check if a node is the literal null
-     */
     function isNullLiteral(node: TSESTree.Node): boolean {
       return node.type === AST_NODE_TYPES.Literal && node.value === null;
     }
 
-    /**
-     * Check if a node is the identifier undefined
-     */
     function isUndefinedIdentifier(node: TSESTree.Node): boolean {
       return (
         node.type === AST_NODE_TYPES.Identifier && node.name === 'undefined'
       );
     }
 
-    /**
-     * Check if a node is a nullish value (null or undefined)
-     */
     function isNullish(node: TSESTree.Node): boolean {
       return isNullLiteral(node) || isUndefinedIdentifier(node);
     }
 
-    /**
-     * Check if a node is a typeof expression
-     */
     function isTypeofExpression(node: TSESTree.Node): boolean {
       return (
         node.type === AST_NODE_TYPES.UnaryExpression &&
@@ -87,9 +75,6 @@ export const preferLooseNullishEquality: TSESLint.RuleModule<
       );
     }
 
-    /**
-     * Get the non-nullish side of a binary expression
-     */
     function getComparedExpression(
       node: TSESTree.BinaryExpression,
     ): TSESTree.Node | null {
@@ -102,25 +87,16 @@ export const preferLooseNullishEquality: TSESLint.RuleModule<
       return null;
     }
 
-    /**
-     * Check if a BinaryExpression checks for null
-     */
     function checksNull(node: TSESTree.BinaryExpression): boolean {
       return isNullLiteral(node.left) || isNullLiteral(node.right);
     }
 
-    /**
-     * Check if a BinaryExpression checks for undefined
-     */
     function checksUndefined(node: TSESTree.BinaryExpression): boolean {
       return (
         isUndefinedIdentifier(node.left) || isUndefinedIdentifier(node.right)
       );
     }
 
-    /**
-     * Compare two AST nodes for semantic equivalence
-     */
     function areExpressionsEquivalent(
       node1: TSESTree.Node | null,
       node2: TSESTree.Node | null,
@@ -129,13 +105,9 @@ export const preferLooseNullishEquality: TSESLint.RuleModule<
         return false;
       }
 
-      // Use source code comparison as a simple heuristic
       return sourceCode.getText(node1) === sourceCode.getText(node2);
     }
 
-    /**
-     * Report a strict nullish comparison and provide a fix
-     */
     function reportStrictNullishComparison(
       node: TSESTree.BinaryExpression,
     ): void {
@@ -160,9 +132,6 @@ export const preferLooseNullishEquality: TSESLint.RuleModule<
       });
     }
 
-    /**
-     * Report a combined null/undefined check and provide a fix
-     */
     function reportCombinedNullishCheck(
       node: TSESTree.LogicalExpression,
       operator: '===' | '!==',
@@ -192,23 +161,19 @@ export const preferLooseNullishEquality: TSESLint.RuleModule<
 
     return {
       BinaryExpression(node: TSESTree.BinaryExpression): void {
-        // Only check strict equality operators
         if (node.operator !== '===' && node.operator !== '!==') {
           return;
         }
 
-        // Don't flag typeof checks
         if (isTypeofExpression(node.left) || isTypeofExpression(node.right)) {
           return;
         }
 
-        // Check if this is part of a combined null/undefined check
-        // If so, the LogicalExpression visitor will handle it
+        // Combined null/undefined checks are handled by LogicalExpression visitor
         const { parent } = node;
         if (parent && parent.type === AST_NODE_TYPES.LogicalExpression) {
           const sibling = parent.left === node ? parent.right : parent.left;
 
-          // Check if both sides are nullish checks on the same variable
           if (
             sibling.type === AST_NODE_TYPES.BinaryExpression &&
             sibling.operator === node.operator &&
@@ -223,13 +188,11 @@ export const preferLooseNullishEquality: TSESLint.RuleModule<
               siblingExpr &&
               areExpressionsEquivalent(thisExpr, siblingExpr)
             ) {
-              // Skip this node - the LogicalExpression visitor will handle it
               return;
             }
           }
         }
 
-        // Check if comparing to null or undefined
         if (isNullish(node.left) || isNullish(node.right)) {
           reportStrictNullishComparison(node);
         }
@@ -238,7 +201,6 @@ export const preferLooseNullishEquality: TSESLint.RuleModule<
       LogicalExpression(node: TSESTree.LogicalExpression): void {
         const { left, right, operator } = node;
 
-        // Must be binary expressions on both sides
         if (
           left.type !== AST_NODE_TYPES.BinaryExpression ||
           right.type !== AST_NODE_TYPES.BinaryExpression
@@ -246,7 +208,7 @@ export const preferLooseNullishEquality: TSESLint.RuleModule<
           return;
         }
 
-        // Pattern 2: a === null || a === undefined
+        // a === null || a === undefined
         if (
           operator === '||' &&
           left.operator === '===' &&
@@ -270,7 +232,7 @@ export const preferLooseNullishEquality: TSESLint.RuleModule<
           }
         }
 
-        // Pattern 3: a !== null && a !== undefined
+        // a !== null && a !== undefined
         if (
           operator === '&&' &&
           left.operator === '!==' &&

--- a/tests/rules/prefer-loose-nullish-equality.test.ts
+++ b/tests/rules/prefer-loose-nullish-equality.test.ts
@@ -1,0 +1,178 @@
+import { preferLooseNullishEquality } from '../../src/rules/prefer-loose-nullish-equality';
+import { createRuleTester } from '../test-utils';
+
+const ruleTester = createRuleTester();
+
+ruleTester.run('prefer-loose-nullish-equality', preferLooseNullishEquality, {
+  valid: [
+    // Already using loose equality
+    { code: 'value == null' },
+    { code: 'value != null' },
+    { code: 'if (value == null) {}' },
+
+    // typeof checks (intentional, should not be flagged)
+    { code: "typeof value === 'undefined'" },
+    { code: "typeof value !== 'undefined'" },
+
+    // Comparing two variables (not nullish comparisons)
+    { code: 'x === y' },
+    { code: 'foo !== bar' },
+
+    // Non-nullish comparisons
+    { code: 'value === 0' },
+    { code: 'value === ""' },
+    { code: 'value === false' },
+    { code: 'value !== true' },
+
+    // Loose equality with other values (allowed)
+    { code: 'value == 0' },
+    { code: 'value == ""' },
+
+    // Nullish coalescence
+    { code: 'const result = value ?? defaultValue' },
+  ],
+
+  invalid: [
+    // Pattern 1: Single strict null check
+    {
+      code: 'value === null',
+      errors: [{ messageId: 'preferLooseNullishEquality' }],
+      output: 'value == null',
+    },
+    {
+      code: 'value !== null',
+      errors: [{ messageId: 'preferLooseNullishEquality' }],
+      output: 'value != null',
+    },
+    {
+      code: 'null === value',
+      errors: [{ messageId: 'preferLooseNullishEquality' }],
+      output: 'value == null',
+    },
+
+    // Pattern 1: Single strict undefined check
+    {
+      code: 'value === undefined',
+      errors: [{ messageId: 'preferLooseNullishEquality' }],
+      output: 'value == null',
+    },
+    {
+      code: 'value !== undefined',
+      errors: [{ messageId: 'preferLooseNullishEquality' }],
+      output: 'value != null',
+    },
+    {
+      code: 'undefined === value',
+      errors: [{ messageId: 'preferLooseNullishEquality' }],
+      output: 'value == null',
+    },
+
+    // Pattern 2: Combined null/undefined OR checks
+    {
+      code: 'value === null || value === undefined',
+      errors: [{ messageId: 'preferLooseNullishEquality' }],
+      output: 'value == null',
+    },
+    {
+      code: 'value === undefined || value === null',
+      errors: [{ messageId: 'preferLooseNullishEquality' }],
+      output: 'value == null',
+    },
+    {
+      code: 'null === value || undefined === value',
+      errors: [{ messageId: 'preferLooseNullishEquality' }],
+      output: 'value == null',
+    },
+
+    // Pattern 3: Combined null/undefined AND checks
+    {
+      code: 'value !== null && value !== undefined',
+      errors: [{ messageId: 'preferLooseNullishEquality' }],
+      output: 'value != null',
+    },
+    {
+      code: 'value !== undefined && value !== null',
+      errors: [{ messageId: 'preferLooseNullishEquality' }],
+      output: 'value != null',
+    },
+    {
+      code: 'null !== value && undefined !== value',
+      errors: [{ messageId: 'preferLooseNullishEquality' }],
+      output: 'value != null',
+    },
+
+    // Complex expressions (property access)
+    {
+      code: 'obj.prop === null',
+      errors: [{ messageId: 'preferLooseNullishEquality' }],
+      output: 'obj.prop == null',
+    },
+    {
+      code: 'obj.prop.nested === undefined',
+      errors: [{ messageId: 'preferLooseNullishEquality' }],
+      output: 'obj.prop.nested == null',
+    },
+
+    // Array indexing
+    {
+      code: 'arr[0] === undefined',
+      errors: [{ messageId: 'preferLooseNullishEquality' }],
+      output: 'arr[0] == null',
+    },
+    {
+      code: 'items[index] !== null',
+      errors: [{ messageId: 'preferLooseNullishEquality' }],
+      output: 'items[index] != null',
+    },
+
+    // Optional chaining
+    {
+      code: 'obj?.prop === null',
+      errors: [{ messageId: 'preferLooseNullishEquality' }],
+      output: 'obj?.prop == null',
+    },
+    {
+      code: 'data?.user?.name !== undefined',
+      errors: [{ messageId: 'preferLooseNullishEquality' }],
+      output: 'data?.user?.name != null',
+    },
+
+    // In if statements (real example from MR #6439)
+    {
+      code: 'if (pageTitle === null || pageTitle === undefined) {}',
+      errors: [{ messageId: 'preferLooseNullishEquality' }],
+      output: 'if (pageTitle == null) {}',
+    },
+
+    // In ternary expressions (real example from MR #6439)
+    {
+      code: 'props.disabled === undefined || props.disabled === null ? {} : { disabled: props.disabled }',
+      errors: [{ messageId: 'preferLooseNullishEquality' }],
+      output: 'props.disabled == null ? {} : { disabled: props.disabled }',
+    },
+    {
+      code: 'const result = value === null ? defaultValue : value',
+      errors: [{ messageId: 'preferLooseNullishEquality' }],
+      output: 'const result = value == null ? defaultValue : value',
+    },
+
+    // Negated expressions
+    {
+      code: '!(value === null || value === undefined)',
+      errors: [{ messageId: 'preferLooseNullishEquality' }],
+      output: '!(value == null)',
+    },
+
+    // Function calls
+    {
+      code: 'getValue() === null',
+      errors: [{ messageId: 'preferLooseNullishEquality' }],
+      output: 'getValue() == null',
+    },
+    {
+      code: 'fetchData() !== undefined',
+      errors: [{ messageId: 'preferLooseNullishEquality' }],
+      output: 'fetchData() != null',
+    },
+  ],
+});

--- a/tests/rules/prefer-loose-nullish-equality.test.ts
+++ b/tests/rules/prefer-loose-nullish-equality.test.ts
@@ -30,6 +30,10 @@ ruleTester.run('prefer-loose-nullish-equality', preferLooseNullishEquality, {
 
     // Nullish coalescence
     { code: 'const result = value ?? defaultValue' },
+
+    // Mixed nullish and other checks (nullish part already using loose equality)
+    { code: "a == null || a === ''" },
+    { code: "a != null && a !== ''" },
   ],
 
   invalid: [
@@ -137,14 +141,14 @@ ruleTester.run('prefer-loose-nullish-equality', preferLooseNullishEquality, {
       output: 'data?.user?.name != null',
     },
 
-    // In if statements (real example from MR #6439)
+    // In if statements
     {
       code: 'if (pageTitle === null || pageTitle === undefined) {}',
       errors: [{ messageId: 'preferLooseNullishEquality' }],
       output: 'if (pageTitle == null) {}',
     },
 
-    // In ternary expressions (real example from MR #6439)
+    // In ternary expressions
     {
       code: 'props.disabled === undefined || props.disabled === null ? {} : { disabled: props.disabled }',
       errors: [{ messageId: 'preferLooseNullishEquality' }],
@@ -173,6 +177,18 @@ ruleTester.run('prefer-loose-nullish-equality', preferLooseNullishEquality, {
       code: 'fetchData() !== undefined',
       errors: [{ messageId: 'preferLooseNullishEquality' }],
       output: 'fetchData() != null',
+    },
+
+    // Mixed nullish and other checks (should flag nullish parts only)
+    {
+      code: "a === null || a === undefined || a === ''",
+      errors: [{ messageId: 'preferLooseNullishEquality' }],
+      output: "a == null || a === ''",
+    },
+    {
+      code: "a !== null && a !== undefined && a !== ''",
+      errors: [{ messageId: 'preferLooseNullishEquality' }],
+      output: "a != null && a !== ''",
     },
   ],
 });


### PR DESCRIPTION
## Summary

- Add new ESLint rule `prefer-loose-nullish-equality` that suggests using `x == null` instead of `x === null || x === undefined` (and vice versa for inequality)
- Provides auto-fix capability to transform the code automatically

## Test plan

- [x] Unit tests added for valid and invalid cases
- [x] Manual testing with example codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)