### PR TITLE
feat(rule): add React type exports to prefer-named-react-imports

### DIFF
--- a/src/rules/prefer-named-react-imports.ts
+++ b/src/rules/prefer-named-react-imports.ts
@@ -7,7 +7,10 @@ import {
 
 type MessageIds = 'preferNamedImport';
 
-type MemberNode = TSESTree.MemberExpression | TSESTree.JSXMemberExpression;
+type MemberNode =
+  | TSESTree.MemberExpression
+  | TSESTree.JSXMemberExpression
+  | TSESTree.TSQualifiedName;
 
 type Violation = {
   node: MemberNode;
@@ -43,6 +46,29 @@ const REACT_EXPORTS = new Set([
   'useState',
   'useSyncExternalStore',
   'useTransition',
+  // Types
+  'ButtonHTMLAttributes',
+  'ChangeEvent',
+  'ComponentProps',
+  'ComponentType',
+  'CSSProperties',
+  'Dispatch',
+  'FC',
+  'FocusEvent',
+  'FormEvent',
+  'FunctionComponent',
+  'HTMLAttributes',
+  'InputHTMLAttributes',
+  'JSX',
+  'KeyboardEvent',
+  'MouseEvent',
+  'MutableRefObject',
+  'PropsWithChildren',
+  'ReactElement',
+  'ReactNode',
+  'Ref',
+  'RefObject',
+  'SetStateAction',
 ]);
 
 export const preferNamedReactImports: TSESLint.RuleModule<
@@ -71,6 +97,16 @@ export const preferNamedReactImports: TSESLint.RuleModule<
     const violations: Array<Violation> = [];
 
     function getReactMemberName(node: MemberNode): string | null {
+      if (node.type === AST_NODE_TYPES.TSQualifiedName) {
+        const { left, right } = node;
+
+        if (left.type !== AST_NODE_TYPES.Identifier || left.name !== 'React') {
+          return null;
+        }
+
+        return REACT_EXPORTS.has(right.name) ? right.name : null;
+      }
+
       const { object, property } = node;
 
       const isReactObject =
@@ -116,6 +152,7 @@ export const preferNamedReactImports: TSESLint.RuleModule<
 
       MemberExpression: checkMemberExpression,
       JSXMemberExpression: checkMemberExpression,
+      TSQualifiedName: checkMemberExpression,
 
       'Program:exit': function handleProgramExit() {
         if (violations.length === 0) {

--- a/tests/rules/prefer-named-react-imports.test.ts
+++ b/tests/rules/prefer-named-react-imports.test.ts
@@ -100,5 +100,15 @@ const x = <React.Fragment>content</React.Fragment>;`,
       output: `import React, { useState, Fragment } from 'react';
 const x = <Fragment>content</Fragment>;`,
     },
+    // React.CSSProperties type usage
+    {
+      code: `import React from 'react';
+const style: React.CSSProperties = { color: 'red' };`,
+      errors: [
+        { messageId: 'preferNamedImport', data: { name: 'CSSProperties' } },
+      ],
+      output: `import React, { CSSProperties } from 'react';
+const style: CSSProperties = { color: 'red' };`,
+    },
   ],
 });


### PR DESCRIPTION
## Summary

- Add 22 TypeScript type exports to the `REACT_EXPORTS` set so the rule catches usages like `React.CSSProperties`, `React.FC`, `React.ReactNode`, etc.
- Handle `TSQualifiedName` AST nodes to detect type annotation usages (e.g., `const style: React.CSSProperties`) in addition to runtime member expressions

## Test plan

- [x] Added test case for `React.CSSProperties` type annotation
- [x] All existing tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.ai/claude-code)